### PR TITLE
Set max width and height for images and figures

### DIFF
--- a/_posts/2024-05-14-markdown-demo-post.md
+++ b/_posts/2024-05-14-markdown-demo-post.md
@@ -76,6 +76,13 @@ Long, single-line code blocks should not wrap. They should horizontally scroll i
 
 ![Minion](https://octodex.github.com/images/minion.png)
 
+### Figure
+
+<figure>
+  <img src="https://octodex.github.com/images/surftocat.png" alt="Surfocat" />
+  <figcaption>Surfocat is is surfing and enjoying themselves.</figcaption>
+</figure>
+
 ### Definition lists can be used with HTML syntax.
 
 <dl>

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -3,7 +3,7 @@ html {
 	color: $primary;
 	font-family: "Jost";
 	line-height: 1.5;
-	max-width: 80ch;
+	max-width: $width;
 	padding: 16px;
 }
 :is(h2, h3, h4, h5, h6) {
@@ -18,7 +18,7 @@ footer ul {
 	align-items: left;
 	display: flex;
 	flex-wrap: wrap;
-	gap: 1em;
+	gap: $gap;
 	list-style-type: none;
 	margin: 0;
 	padding: 0;
@@ -38,7 +38,20 @@ footer hr {
 
 // Images
 img {
-	max-width: 100%;
+	max-width: calc(0.8 * #{$width});
+	max-height: calc(0.6 * #{$width});
+}
+
+figure {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: $gap;
+}
+
+figure figcaption {
+	max-width: calc(0.8 * #{$width});
+	font-size: 95%;
 }
 
 // Lists

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -4,3 +4,7 @@ $primary: #222;
 // Typography
 $indentation: 20px;
 $border: 1px solid $primary;
+
+// Size
+$width: 80ch;
+$gap: 1em;


### PR DESCRIPTION
I have added max width and height for images and figures. I have also added an example of a figure to the `markdown_demo_post.md`.